### PR TITLE
Selectable recipe header, remove whitespace

### DIFF
--- a/userscripts/InfiniteCraftHelper/index.user.js
+++ b/userscripts/InfiniteCraftHelper/index.user.js
@@ -46,7 +46,7 @@
             return 1;
         return current.localeCompare(latest, undefined, { numeric: true, sensitivity: 'case', caseFirst: 'upper' }) === -1;
     }
-    
+
     function init$d(elements) {
         GM.xmlHttpRequest({
             method: 'GET',
@@ -354,9 +354,16 @@
         font-family: Roboto, sans-serif;
         line-height: 35px;
         color: var(--text-color);
+    }
+
+    .modal-title:not(:has(.display-item-emoji)) {
         -webkit-user-select: none;
         -moz-user-select: none;
         user-select: none;
+    }
+
+    .modal-title .display-item-emoji {
+        padding-right: .3em;
     }
 
     .modal-text {
@@ -442,7 +449,7 @@
         pointer-events: none;
     }
 `;
-    
+
     function init$b(elements) {
         elements.styles.appendChild(document.createTextNode(css.trim()));
         document.getElementsByTagName('head')[0].appendChild(elements.styles);
@@ -457,7 +464,7 @@
     window.addEventListener('keyup', (event) => {
         keysPressed[event.key] = false;
     });
-    
+
     function setMiddleClickOnMutations(mutations, elements) {
        for (const mutation of mutations) {
             if (mutation.addedNodes.length > 0) {
@@ -563,7 +570,7 @@
             craftsModal.close();
         });
     }
-    
+
     async function addElementToCrafts(first, second, result, loading = false) {
         const ingredients = [first, second].sort((a, b) => {
             if (a.text > b.text) return 1;
@@ -590,14 +597,14 @@
             await GM.setValue('recipes', JSON.stringify(recipes));
         }
     }
-    
+
     function openCraftsForElement(element) {
         craftsTitle.innerHTML = '';
         const titleEmoji = document.createElement('span');
         titleEmoji.classList.add('display-item-emoji');
         titleEmoji.appendChild(document.createTextNode(element.emoji ?? '⬜'));
         craftsTitle.appendChild(titleEmoji);
-        craftsTitle.appendChild(document.createTextNode(` ${element.text} `));
+        craftsTitle.appendChild(document.createTextNode(element.text));
         craftsContainer.innerHTML = '';
         const elementRecipes = recipes[element.text];
         if (elementRecipes === undefined) {
@@ -659,7 +666,7 @@
         }
         craftsModal.showModal();
     }
-    
+
     async function resetCrafts() {
         recipes = {};
         await GM.setValue('recipes', '{}');
@@ -1781,7 +1788,7 @@
                         return cloneInto(elements.filter((el) => el.discovered), unsafeWindow);
                     }
                     if (unsafeWindow.$nuxt.$root.$children[1].$children[0].$children[0]._data.sortBy === 'name') {
-                        return cloneInto(elements, unsafeWindow).sort((a, b) => 
+                        return cloneInto(elements, unsafeWindow).sort((a, b) =>
                             (a.text > b.text ? 1 : a.text < b.text ? -1 : 0)
                         );
                     }
@@ -1789,7 +1796,7 @@
                         return cloneInto(elements, unsafeWindow).sort((a, b) => {
                             const emojiA = a.emoji ?? '⬜';
                             const emojiB = b.emoji ?? '⬜';
-                        
+
                             return emojiA > emojiB ? 1 : emojiA < emojiB ? -1 : 0;
                         });
                     }
@@ -1965,7 +1972,7 @@
         init(elements);
         dispatchEvent(new Event('helper-load'))
     }, false);
-    
+
     window.addEventListener('contextmenu', (e) => {
         e.preventDefault();
     });

--- a/userscripts/SaveFileInfo/index.user.js
+++ b/userscripts/SaveFileInfo/index.user.js
@@ -24,8 +24,14 @@ window.addEventListener("load", async () => {
     // which ruins muscle memory because the order is always random
     setTimeout(() => document.querySelector(".side-controls").append(button), 1);
 
-    $injectStyle(".modal{margin:auto;max-width:75%;max-height:75%;padding-top:0px;border:1px solid var(--border-color);background-color:var(--background-color);font-family:Roboto,sans-serif;border-radius:5px;outline:none!important}.modal::backdrop{background-color:rgba(0,0,0,.5)}.modal-header{position:sticky;top:0;display:flex;gap:1rem;padding-top:16px;padding-bottom:16px;justify-content:space-between;align-items:center;align-content:center;background-color:var(--background-color)user-select:none}.modal-title{font-size:20px;line-height:35px;color:var(--text-color)}.modal-text{font-size:15px;color:var(--text-color);user-select:none;pointer-events:unset!important;text-align:left!important}");
+    $injectStyle(".modal{margin:auto;max-width:75%;max-height:75%;padding-top:0px;border:1px solid var(--border-color);background-color:var(--background-color);font-family:Roboto,sans-serif;border-radius:5px;outline:none!important}.modal::backdrop{background-color:rgba(0,0,0,.5)}.modal-header{position:sticky;top:0;display:flex;gap:1rem;padding-top:16px;padding-bottom:16px;justify-content:space-between;align-items:center;align-content:center;background-color:var(--background-color)}.modal-title{font-size:20px;line-height:35px;color:var(--text-color)}.modal-text{font-size:15px;color:var(--text-color);user-select:none;pointer-events:unset!important;text-align:left!important}");
     $injectStyle(`
+        #savefile_info .modal-header {
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            user-select: none;
+        }
+
         #savefile_info .modal-text > div {
             display: grid;
             grid-template-columns: 1fr 1.25fr;


### PR DESCRIPTION
Makes the element emoji and name in the recipe modal selectable:
![image](https://github.com/user-attachments/assets/3972f331-130f-457b-a4b3-af953aa5b26d)

Also fixes background-color in savefileinfo that affected the recipes window and anything else that used modal:
![image](https://github.com/user-attachments/assets/ad9f4572-f519-4690-ba00-9a19f17a1226)
